### PR TITLE
op3: Fix slow motion recording in Google Camera

### DIFF
--- a/configs/media_profiles.xml
+++ b/configs/media_profiles.xml
@@ -445,6 +445,60 @@
             channels="2" />
     </EncoderProfile>
 
+    <!-- CAMCORDER_QUALITY_HIGH_SPEED_LOW/720P : 720p@240fps; 42.0 Mbps -->
+    <EncoderProfile quality="highspeedlow" fileFormat="mp4" duration="30">
+        <Video codec="h264"
+            bitRate="42000000"
+            width="1280"
+            height="720"
+            frameRate="240" />
+        <!-- audio setting is ignored -->
+        <Audio codec="aac"
+            bitRate="96000"
+            sampleRate="48000"
+            channels="1" />
+    </EncoderProfile>
+
+    <!-- CAMCORDER_QUALITY_HIGH_SPEED_HIGH/1080P : 1080p@120fps; 42.0 Mbps -->
+    <EncoderProfile quality="highspeedhigh" fileFormat="mp4" duration="30">
+        <Video codec="h264"
+            bitRate="42000000"
+            width="1920"
+            height="1080"
+            frameRate="120" />
+        <!-- audio setting is ignored -->
+        <Audio codec="aac"
+            bitRate="96000"
+            sampleRate="48000"
+            channels="1" />
+    </EncoderProfile>
+
+    <EncoderProfile quality="highspeed720p" fileFormat="mp4" duration="30">
+        <Video codec="h264"
+            bitRate="42000000"
+            width="1280"
+            height="720"
+            frameRate="240" />
+        <!-- audio setting is ignored -->
+        <Audio codec="aac"
+            bitRate="96000"
+            sampleRate="48000"
+            channels="1" />
+    </EncoderProfile>
+
+    <EncoderProfile quality="highspeed1080p" fileFormat="mp4" duration="30">
+        <Video codec="h264"
+            bitRate="42000000"
+            width="1920"
+            height="1080"
+            frameRate="120" />
+        <!-- audio setting is ignored -->
+        <Audio codec="aac"
+            bitRate="96000"
+            sampleRate="48000"
+            channels="1" />
+    </EncoderProfile>
+
         <ImageEncoding quality="95" />
         <ImageEncoding quality="80" />
         <ImageEncoding quality="70" />


### PR DESCRIPTION
This change fixes the slowmotion functionality of Google Camera and is based on [THIS commit](https://github.com/LineageOS/android_device_motorola_griffin/commit/7710f7443906f8c5031b0afce5fa75ca6acffb41#diff-813d8fba57c8900923f28c4cacd11bd2). Without this fix Google Camera just crashes when selection Slowmotion because it misses some media_profiles: highspeedlow, highspeedhigh, highspeed720p, highspeed1080p. After applying this fix Google Camera allows for recording at 120fps. I tested Snap after using the fix and could not find any new problems so it should be fine to just add these profiles.

Full credits go to the owner of the commit this change is based on.